### PR TITLE
Update bootstrap-timepicker.js

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -1,13 +1,15 @@
+//TODO: move arrow styles and button click code into configurable items, with defaults matching the existing code
+
 /*!
- * Timepicker Component for Twitter Bootstrap
- *
- * Copyright 2013 Joris de Wit
- *
- * Contributors https://github.com/jdewit/bootstrap-timepicker/graphs/contributors
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
+* Timepicker Component for Twitter Bootstrap
+*
+* Copyright 2013 Joris de Wit
+*
+* Contributors https://github.com/jdewit/bootstrap-timepicker/graphs/contributors
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
 (function($, window, document, undefined) {
   'use strict';
 
@@ -26,6 +28,9 @@
     this.showSeconds = options.showSeconds;
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
+	this.upArrowStyle = options.upArrowStyle;
+	this.downArrowStyle = options.downArrowStyle;
+	this.containerClass = options.containerClass;
 
     this._init();
   };
@@ -38,9 +43,16 @@
       var self = this;
 
       if (this.$element.parent().hasClass('input-append') || this.$element.parent().hasClass('input-prepend')) {
-        this.$element.parent('.input-append, .input-prepend').find('.add-on').on({
-          'click.timepicker': $.proxy(this.showWidget, this)
-        });
+		if (this.$element.parent('.input-append, .input-prepend').find('.add-on').length) {
+			this.$element.parent('.input-append, .input-prepend').find('.add-on').on({
+			  'click.timepicker': $.proxy(this.showWidget, this)
+			});		
+		} else {
+			this.$element.closest(this.containerClass).find('.add-on').on({
+			  'click.timepicker': $.proxy(this.showWidget, this)
+			});		
+		}
+		
         this.$element.on({
           'focus.timepicker': $.proxy(this.highlightUnit, this),
           'click.timepicker': $.proxy(this.highlightUnit, this),
@@ -271,16 +283,16 @@
 
       templateContent = '<table>'+
          '<tr>'+
-           '<td><a href="#" data-action="incrementHour"><i class="glyphicon glyphicon-chevron-up"></i></a></td>'+
+           '<td><a href="#" data-action="incrementHour"><i class="' + this.upArrowStyle + '"></i></a></td>'+
            '<td class="separator">&nbsp;</td>'+
-           '<td><a href="#" data-action="incrementMinute"><i class="glyphicon glyphicon-chevron-up"></i></a></td>'+
+           '<td><a href="#" data-action="incrementMinute"><i class="' + this.upArrowStyle + '"></i></a></td>'+
            (this.showSeconds ?
              '<td class="separator">&nbsp;</td>'+
-             '<td><a href="#" data-action="incrementSecond"><i class="glyphicon glyphicon-chevron-up"></i></a></td>'
+             '<td><a href="#" data-action="incrementSecond"><i class="' + this.upArrowStyle + '"></i></a></td>'
            : '') +
            (this.showMeridian ?
              '<td class="separator">&nbsp;</td>'+
-             '<td class="meridian-column"><a href="#" data-action="toggleMeridian"><i class="glyphicon glyphicon-chevron-up"></i></a></td>'
+             '<td class="meridian-column"><a href="#" data-action="toggleMeridian"><i class="' + this.upArrowStyle + '"></i></a></td>'
            : '') +
          '</tr>'+
          '<tr>'+
@@ -297,16 +309,16 @@
            : '') +
          '</tr>'+
          '<tr>'+
-           '<td><a href="#" data-action="decrementHour"><i class="glyphicon glyphicon-chevron-down"></i></a></td>'+
+           '<td><a href="#" data-action="decrementHour"><i class="' + this.downArrowStyle + '"></i></a></td>'+
            '<td class="separator"></td>'+
-           '<td><a href="#" data-action="decrementMinute"><i class="glyphicon glyphicon-chevron-down"></i></a></td>'+
+           '<td><a href="#" data-action="decrementMinute"><i class="' + this.downArrowStyle + '"></i></a></td>'+
            (this.showSeconds ?
             '<td class="separator">&nbsp;</td>'+
-            '<td><a href="#" data-action="decrementSecond"><i class="glyphicon glyphicon-chevron-down"></i></a></td>'
+            '<td><a href="#" data-action="decrementSecond"><i class="' + this.downArrowStyle + '"></i></a></td>'
            : '') +
            (this.showMeridian ?
             '<td class="separator">&nbsp;</td>'+
-            '<td><a href="#" data-action="toggleMeridian"><i class="glyphicon glyphicon-chevron-down"></i></a></td>'
+            '<td><a href="#" data-action="toggleMeridian"><i class="' + this.downArrowStyle + '"></i></a></td>'
            : '') +
          '</tr>'+
        '</table>';
@@ -343,9 +355,9 @@
         return;
       }
 
-			if (this.showInputs) {
-				this.updateFromWidgetInputs();
-			}
+                        if (this.showInputs) {
+                                this.updateFromWidgetInputs();
+                        }
 
       this.$element.trigger({
         'type': 'hide.timepicker',
@@ -439,11 +451,11 @@
 
       this.highlightedUnit = 'hour';
 
-			if ($element.setSelectionRange) {
-				setTimeout(function() {
-					$element.setSelectionRange(0,2);
-				}, 0);
-			}
+                        if ($element.setSelectionRange) {
+                                setTimeout(function() {
+                                        $element.setSelectionRange(0,2);
+                                }, 0);
+                        }
     },
 
     highlightMinute: function() {
@@ -451,11 +463,11 @@
 
       this.highlightedUnit = 'minute';
 
-			if ($element.setSelectionRange) {
-				setTimeout(function() {
-					$element.setSelectionRange(3,5);
-				}, 0);
-			}
+                        if ($element.setSelectionRange) {
+                                setTimeout(function() {
+                                        $element.setSelectionRange(3,5);
+                                }, 0);
+                        }
     },
 
     highlightSecond: function() {
@@ -463,11 +475,11 @@
 
       this.highlightedUnit = 'second';
 
-			if ($element.setSelectionRange) {
-				setTimeout(function() {
-					$element.setSelectionRange(6,8);
-				}, 0);
-			}
+                        if ($element.setSelectionRange) {
+                                setTimeout(function() {
+                                        $element.setSelectionRange(6,8);
+                                }, 0);
+                        }
     },
 
     highlightMeridian: function() {
@@ -475,17 +487,17 @@
 
       this.highlightedUnit = 'meridian';
 
-			if ($element.setSelectionRange) {
-				if (this.showSeconds) {
-					setTimeout(function() {
-						$element.setSelectionRange(9,11);
-					}, 0);
-				} else {
-					setTimeout(function() {
-						$element.setSelectionRange(6,8);
-					}, 0);
-				}
-			}
+                        if ($element.setSelectionRange) {
+                                if (this.showSeconds) {
+                                        setTimeout(function() {
+                                                $element.setSelectionRange(9,11);
+                                        }, 0);
+                                } else {
+                                        setTimeout(function() {
+                                                $element.setSelectionRange(6,8);
+                                        }, 0);
+                                }
+                        }
     },
 
     incrementHour: function() {
@@ -723,11 +735,11 @@
     },
 
     updateFromElementVal: function() {
-			var val = this.$element.val();
+                        var val = this.$element.val();
 
-			if (val) {
-				this.setTime(val);
-			}
+                        if (val) {
+                                this.setTime(val);
+                        }
     },
 
     updateWidget: function() {
@@ -880,7 +892,10 @@
     showInputs: true,
     showMeridian: true,
     template: 'dropdown',
-    appendWidgetTo: '.bootstrap-timepicker'
+    appendWidgetTo: '.bootstrap-timepicker',
+	upArrowStyle: 'glyphicon glyphicon-chevron-up',
+	downArrowStyle: 'glyphicon glyphicon-chevron-down',
+	containerClass: 'bootstrap-timepicker'
   };
 
   $.fn.timepicker.Constructor = Timepicker;


### PR DESCRIPTION
Changes to the file cover the following:
- creating optional arguments for the icon to use for the up and down arrows in the modal (left the default of 'glyphicon glyphicon-chevron-up' and 'glyphicon glyphicon-chevron-down', but using bootstrap 3 we were passing 'icon-chevron-up' and 'icon-chevron-down'.
- created a new optional parameter of "containerClass" (default is "bootstrap-timepicker", which matches the existing example markup), which allows to either using the existing example mockup, or create more modularized markup and have the js support it.

As an example, consider the following:

<div class="form-group multi-field" id="endTime-block">
    <div class="form-control-container-time input-append bootstrap-timepicker">
        <input id="endTime" type="text" class="form-control" data-minute-step="1" /></span>
    </div><!-- close .form-control-input-group-btn -->
    <div class="form-control-input-group-btn">
        <button class="btn btn-secondary add-on" type="button" id="endTimeBtn"><i class="icon-time"></i> <span>GMT</span></button>
    </div><!-- close .form-control-input-group-btn -->
</div><!-- close .multi-field -->

<script type="text/javascript">
    $('#endTime').timepicker({upArrowStyle:'icon-chevron-up',downArrowStyle:'icon-chevron-down',containerClass:'.form-group'});
</script>
