### PR TITLE
Fix unhandled exception when clicking input addons and don't pad hour.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -237,7 +237,7 @@
     },
 
     formatTime: function(hour, minute, second, meridian) {
-      hour = hour < 10 ? '0' + hour : hour;
+      //hour = hour < 10 ? '0' + hour : hour;
       minute = minute < 10 ? '0' + minute : minute;
       second = second < 10 ? '0' + second : second;
 
@@ -664,7 +664,7 @@
     },
 
     showWidget: function() {
-      if (this.isOpen) {
+      if (this.isOpen || this.template !== 'modal') {
         return;
       }
 
@@ -697,7 +697,7 @@
 
       this.updateFromElementVal();
 
-      if (this.template === 'modal' && this.$widget.modal) {
+      if (this.$widget.modal) {
         this.$widget.modal('show').on('hidden', $.proxy(this.hideWidget, this));
       } else {
         if (this.isOpen === false) {


### PR DESCRIPTION
When clicking an input addon I get an unhandled exception. I've added a check for template at the top to make sure that doesn't happen.

I also don't think adding leading zeroes to the hour is ideal unless explicitly requested.

This is for review/discussion - it works, but changes are obviously welcome! :)
